### PR TITLE
View host stats by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 etc/config.local.php
+bootstrap/

--- a/memcache.php
+++ b/memcache.php
@@ -180,6 +180,7 @@ echo getMenu();
 
 switch ($_GET['op']) {
 
+    default:
     case 1: // host stats
         $phpversion = phpversion();
         $memcacheStats = getMemcacheStats();


### PR DESCRIPTION
Title says all. It think it's nicer to see some stats immediately when hitting the page.

Also added a .gitignore line for the now necessary bootstrap install.